### PR TITLE
Potential fix for code scanning alert no. 4: Shell command built from environment values

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/scripts/DownloadMocks.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/scripts/DownloadMocks.ts
@@ -1,4 +1,4 @@
-import {execSync} from 'child_process';
+import {execFileSync} from 'child_process';
 import fs from 'fs';
 import path from 'path';
 
@@ -29,7 +29,12 @@ it(`builds mocks`, () => {
       mock.workspace ? 'workspace' : 'repository'
     }.yaml`;
 
-    execSync(`dagster-graphql -y ${repo} -t '${query}' ${vars} > ${mock.filepath}`);
+    const args = ['-y', repo, '-t', query];
+    if (vars) {
+      args.push('-v', JSON.stringify(mock.variables));
+    }
+    execFileSync('dagster-graphql', args, { stdio: 'pipe', encoding: 'utf-8' });
+    fs.writeFileSync(mock.filepath, execFileSync('dagster-graphql', args));
 
     if (JSON.parse(fs.readFileSync(mock.filepath).toString()).errors) {
       throw new Error(`Failed to generate ${mock.filepath}. See file for GraphQL error.`);


### PR DESCRIPTION
Potential fix for [https://github.com/Git-Hub-Chris/Dagster/security/code-scanning/4](https://github.com/Git-Hub-Chris/Dagster/security/code-scanning/4)

To fix the problem, we should avoid constructing the shell command as a single string and instead use the `execFileSync` method, which allows us to pass arguments separately. This approach ensures that special characters in the arguments do not alter the shell command unexpectedly.

- Replace the `execSync` call with `execFileSync`.
- Construct the command and its arguments separately.
- Ensure that all dynamic values are passed as arguments to avoid shell interpretation.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
