### PR TITLE
Potential fix for code scanning alert no. 26: Use of a broken or weak cryptographic hashing algorithm on sensitive data

### DIFF
--- a/python_modules/dagster/dagster/_utils/security.py
+++ b/python_modules/dagster/dagster/_utils/security.py
@@ -4,9 +4,5 @@ from typing import Union
 
 
 def non_secure_md5_hash_str(s: Union[bytes, bytearray, memoryview]) -> str:
-    """Drop in replacement md5 hash function marking it for a non-security purpose."""
-    # check python version, use usedforsecurity flag if possible.
-    if sys.version_info[0] <= 3 and sys.version_info[1] <= 8:
-        return hashlib.md5(s).hexdigest()
-    else:
-        return hashlib.md5(s, usedforsecurity=False).hexdigest()
+    """Drop in replacement hash function marking it for a non-security purpose."""
+    return hashlib.sha256(s).hexdigest()


### PR DESCRIPTION
Potential fix for [https://github.com/Git-Hub-Chris/Dagster/security/code-scanning/26](https://github.com/Git-Hub-Chris/Dagster/security/code-scanning/26)

To fix the problem, we should replace the use of the MD5 hashing algorithm with a stronger, modern cryptographic hash function. Since the function is explicitly marked for non-security purposes, we can use SHA-256, which is a strong cryptographic hashing function suitable for general purposes. This change will ensure that the hashing algorithm is secure, even if the function is used in a security context in the future.

- Replace the MD5 hashing algorithm with SHA-256 in the `non_secure_md5_hash_str` function.
- Update the import statements if necessary.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
